### PR TITLE
Smartfan v6 and Bookworm OS Support

### DIFF
--- a/boards/Constants.ts
+++ b/boards/Constants.ts
@@ -52,7 +52,8 @@ export class valueMaps {
     public controllerTypes: valueMap = new valueMap([
         [1, { name: 'raspi', desc: 'Raspberry Pi', pinouts:'raspi.json', spi0:true, spi1:true, i2c:true }],
         [2, { name: 'opi', desc: 'Orange Pi', pinouts:'orangepi.json', spi0: true, spi1:true, i2c:true }],
-        [3, { name: 'beagle', desc: 'Beagle Bone Black', pinouts: 'beaglebone.json', spi0: true, spi1: false, i2c: true }]
+        [3, { name: 'beagle', desc: 'Beagle Bone Black', pinouts: 'beaglebone.json', spi0: true, spi1: false, i2c: true }],
+        [4, { name: 'raspi-4b-bookworm', desc: 'Raspberry Pi 4B Bookworm OS', pinouts:'raspi-4b-bookworm.json', spi0:true, spi1:true, i2c:true }],
     ]);
     public pinDirections: valueMap = new valueMap([
         [0, { name: 'input', desc: 'Input', gpio:'in' }],

--- a/devices/SequentSmartFan.json
+++ b/devices/SequentSmartFan.json
@@ -1051,7 +1051,7 @@
     {
       "id": 1002,
       "enabled": true,
-      "name": "Sequent Smart Fan v4+",
+      "name": "Sequent Smart Fan v4 and v5",
       "deviceClass": "SequentSmartFan",
       "module": "./SequentSmartFan",
       "hasReset": false,
@@ -1905,6 +1905,767 @@
         }
       ],
       "interfaces": [ "i2c" ]
+    },
+    {
+      "id": 1003,
+      "enabled": true,
+      "name": "Sequent Smart Fan v6+",
+      "deviceClass": "SequentSmartFanV6",
+      "module": "./SequentSmartFan_v6",
+      "hasReset": false,
+      "hasChangeAddress": false,
+      "readings": {
+        "fanTemp": {
+          "label": "Fan Temperature",
+          "interval": {
+            "min": 2000,
+            "max": 99000,
+            "default": 10000
+          }
+        }
+      },
+      "outputs": [            
+        {
+          "name": "fwversion",
+          "desc": "Firmware Version",
+          "maxSamples": 50
+        },      
+        {
+          "name": "fanPower",
+          "desc": "Fan Power",
+          "maxSamples": 50
+        }
+      ],
+      "inputs": [
+        {
+          "name": "fanPower",
+          "desc": "Fan Power",
+          "dataType": "number"
+        }
+      ],
+      "options": [
+        {
+          "dataType": "panel",
+          "field": {
+            "type": "tabBar",
+            "style": {
+              "display": "inline-block"
+            }
+          },
+          "tabs": [
+            {
+              "field": {
+                "text": "General",
+                "id": "tabGeneral"
+              },
+              "options": [
+                {
+                  "dataType": "string",
+                  "default": "",
+                  "field": {
+                    "type": "inputField",
+                    "required": false,
+                    "bind": "options.name",
+                    "labelText": "Name",
+                    "inputAttrs": {
+                      "maxLength": 16,
+                      "style": {
+                        "width": "16rem"
+                      }
+                    },
+                    "style": {
+                      "display": "block"
+                    }
+                  }
+                },  
+                {
+                  "field": {
+                    "type": "pickList",
+                    "labelText": "Units",
+                    "binding": "options.units",
+                    "bindColumn": 0,
+                    "displayColumn": 1,
+                    "style": {
+                      "display": "block",
+                      "marginTop": ".25rem",
+                      "marginBottom": ".25rem",
+                      "verticalAlign": "middle"
+
+                    },
+                    "labelAttrs": {
+                      "style": {
+                        "width": "3rem"
+                      }
+                    },
+                    "columns": [
+                      {
+                        "hidden": true,
+                        "binding": "name",
+                        "text": "name",
+                        "style": {
+                          "whiteSpace": "nowrap"
+                        }
+                      },
+                      {
+                        "hidden": false,
+                        "binding": "desc",
+                        "text": "Description",
+                        "style": {
+                          "whiteSpace": "nowrap"
+                        }
+                      }
+                    ],
+                    "items": [
+                      {
+                        "name": "F",
+                        "desc": "Fahrenheit"
+                      },
+                      {
+                        "name": "C",
+                        "desc": "Celsius"
+                      },
+                      {
+                        "name": "K",
+                        "desc": "Kelvin"
+                      }
+                    ],
+                    "inputAttrs": {
+                      "style": {
+                        "width": "7rem"
+                      }
+                    }
+                  }
+                },              
+                {
+                  "dataType": "panel",
+                  "field": {
+                    "type": "fieldset",
+                    "legend": "Device Info",
+                    "style": {
+                      "display": "block",
+                      "verticalAlign": "top"
+                    },
+                    "cssClass": "i2cDeviceInformation"
+                  },
+                  "options": [
+                    {
+                      "field": {
+                        "type": "staticField",
+                        "labelText": "Hardware",
+                        "binding": "info.hwVersion",
+                        "style": {
+                          "display": "block",
+                          "fontSize": ".8rem",
+                          "lineHeight": "1.2"
+                        },
+                        "labelAttrs": {
+                          "style": {
+                            "width": "5.5rem"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "dataType": "panel",
+                  "field": {
+                    "type": "fieldset",
+                    "legend": "Readings",
+                    "cssClass": "i2cReadingValues",
+                    "style": {
+                      "display": "block",
+                      "verticalAlign": "top"
+                    }
+                  },
+                  "options": [                   
+                    {
+                      "field": {
+                        "type": "staticField",
+                        "labelText": "Fan Power",
+                        "binding": "values.fanPower",
+                        "dataType": "number",
+                        "fmtMask": "#,##0",
+                        "emptyMask": "--.-",
+                        "units": "%",
+                        "labelAttrs": {
+                          "style": {
+                            "width": "7rem",
+                            "fontSize": ".8rem"
+                          }
+                        },
+                        "style": {
+                          "fontSize": ".8rem",
+                          "display": "block",
+                          "line-height": "1.2"
+                        }
+                      }
+                    },
+                    {
+                      "field": {
+                        "type": "staticField",
+                        "labelText": "Target Power",
+                        "binding": "values.fanPowerFnVal",
+                        "dataType": "number",
+                        "fmtMask": "#,##0",
+                        "emptyMask": "--.-",
+                        "units": "%",
+                        "labelAttrs": {
+                          "style": {
+                            "width": "7rem",
+                            "fontSize": ".8rem",
+                            "line-height": "1.2"
+                          }
+                        },
+                        "style": {
+                          "fontSize": ".8rem",
+                          "display": "block",
+                          "line-height": "1.2"
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "field": {
+                "text": "Fan Curve",
+                "id": "tabFanCurve",
+                "style": { "width": "30rem" }
+              },
+              "options": [
+                {
+                  "field": {
+                    "type": "pickList",
+                    "labelText": "Fan Curve",
+                    "binding": "options.fanCurve.curve",
+                    "bindColumn": 0,
+                    "displayColumn": 1,
+                    "style": {
+                      "display": "block",
+                      "marginLeft": ".25rem",
+                      "marginBottom": ".25rem"
+                    },
+                    "labelAttrs": {
+                      "style": {
+                        "width": "5rem"
+                      }
+                    },
+                    "columns": [
+                      {
+                        "hidden": true,
+                        "binding": "name",
+                        "text": "name",
+                        "style": {
+                          "whiteSpace": "nowrap"
+                        }
+                      },
+                      {
+                        "hidden": false,
+                        "binding": "desc",
+                        "text": "Description",
+                        "style": {
+                          "whiteSpace": "nowrap"
+                        }
+                      }
+                    ],
+                    "items": [
+                      {
+                        "name": "linear",
+                        "desc": "Linear"
+                      },
+                      {
+                        "name": "log",
+                        "desc": "Logarithmic"
+                      },
+                      {
+                        "name": "exp",
+                        "desc": "Exponential"
+                      },
+                      {
+                        "name": "custom",
+                        "desc": "Custom Script"
+                      }
+                    ],
+                    "inputAttrs": {
+                      "style": {
+                        "width": "7rem"
+                      }
+                    },
+                    "fieldEvents": {
+                      "selchanged": "console.log(evt); $(evt.currentTarget).parent().find(`.fan-curve`).each(function() { this.style.display = $(this).hasClass(`fan-curve-${evt.newItem.name}`) ? 'block' : 'none';});"
+                    }
+                  }
+                },
+                {
+                  "field": {
+                    "type": "fieldset",
+                    "legend": "Linear Fan Curve",
+                    "cssClass": "fan-curve fan-curve-linear",
+                    "style": {
+                    },
+                    "attrs": {
+                      "data-bindingcontext": "settings"
+                    }
+                  },
+                  "options": [
+                    {
+                      "field": {
+                        "type": "div"
+                      },
+                      "options": [
+                        {
+                          "field": {
+                            "binding": "options.fanCurve.linear.start",
+                            "type": "valueSpinner",
+                            "labelText": "Start Temp",
+                            "canEdit": true,
+                            "min": -100,
+                            "max": 500,
+                            "step": 1,
+                            "fmtMask": "##,##0",
+                            "units": "&deg;",
+                            "labelAttrs": {
+                              "style": {
+                                "width": "5.5em"
+                              }
+                            },
+                            "style": {
+                              "marginLeft": ".25rem",
+                              "marginBottom": ".25rem"
+                            },
+                            "inputAttrs": {
+                              "style": {
+                                "width": "5rem"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "field": {
+                            "binding": "values.units",
+                            "type": "span",
+                            "cssClass": "picSpinner-units picUnits"
+                          }
+                        }
+
+                      ]
+                    },
+                    {
+                      "field": {
+                        "type": "div"
+                      },
+                      "options": [
+                        {
+                          "field": {
+                            "binding": "options.fanCurve.linear.end",
+                            "type": "valueSpinner",
+                            "labelText": "End Temp",
+                            "canEdit": true,
+                            "min": -100,
+                            "max": 500,
+                            "step": 1,
+                            "fmtMask": "##,##0",
+                            "units": "&deg;",
+                            "labelAttrs": {
+                              "style": {
+                                "width": "5.5em"
+                              }
+                            },
+                            "style": {
+                              "marginLeft": ".25rem",
+                              "marginBottom": ".25rem"
+                            },
+                            "inputAttrs": {
+                              "style": {
+                                "width": "5rem"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "field": {
+                            "binding": "values.units",
+                            "type": "span",
+                            "cssClass": "picSpinner-units picUnits"
+                          }
+                        }
+
+                      ]
+                    },
+                    {
+                      "field": {
+                        "binding": "options.fanCurve.linear.min",
+                        "type": "valueSpinner",
+                        "labelText": "Min Power",
+                        "canEdit": true,
+                        "min": 0,
+                        "max": 100,
+                        "step": 1,
+                        "fmtMask": "##,##0",
+                        "units": "%",
+                        "labelAttrs": {
+                          "style": {
+                            "width": "5.5em"
+                          }
+                        },
+                        "style": {
+                          "marginLeft": ".25rem",
+                          "marginBottom": ".25rem"
+                        },
+                        "inputAttrs": {
+                          "style": {
+                            "width": "5rem"
+                          }
+                        }
+                      }
+                    }
+
+
+
+                  ]
+                },
+                {
+                  "field": {
+                    "type": "fieldset",
+                    "legend": "Logarithmic Fan Curve",
+                    "cssClass": "fan-curve fan-curve-log",
+                    "style": {
+                    },
+                    "attrs": {
+                      "data-bindingcontext": "settings"
+                    }
+                  },
+                  "options": [
+                    {
+                      "field": {
+                        "type": "div"
+                      },
+                      "options": [
+                        {
+                          "field": {
+                            "binding": "options.fanCurve.log.start",
+                            "type": "valueSpinner",
+                            "labelText": "Start Temp",
+                            "canEdit": true,
+                            "min": 0,
+                            "max": 500,
+                            "step": 1,
+                            "fmtMask": "##,##0",
+                            "units": "&deg;",
+                            "labelAttrs": {
+                              "style": {
+                                "width": "5.5em"
+                              }
+                            },
+                            "style": {
+                              "marginLeft": ".25rem",
+                              "marginBottom": ".25rem"
+                            },
+                            "inputAttrs": {
+                              "style": {
+                                "width": "5rem"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "field": {
+                            "binding": "values.units",
+                            "type": "span",
+                            "cssClass": "picSpinner-units picUnits"
+                          }
+                        }
+
+                      ]
+                    },
+                    {
+                      "field": {
+                        "type": "pickList",
+                        "labelText": "Ramp",
+                        "binding": "options.fanCurve.log.ramp",
+                        "bindColumn": 0,
+                        "displayColumn": 1,
+                        "style": {
+                          "display": "block",
+                          "marginLeft": ".25rem",
+                          "marginBottom": ".25rem"
+                        },
+                        "labelAttrs": {
+                          "style": {
+                            "width": "5.5rem"
+                          }
+                        },
+                        "columns": [
+                          {
+                            "hidden": true,
+                            "binding": "name",
+                            "text": "name",
+                            "style": {
+                              "whiteSpace": "nowrap"
+                            }
+                          },
+                          {
+                            "hidden": false,
+                            "binding": "desc",
+                            "text": "Description",
+                            "style": {
+                              "whiteSpace": "nowrap"
+                            }
+                          }
+                        ],
+                        "items": [
+                          {
+                            "name": "slow",
+                            "desc": "Slow"
+                          },
+                          {
+                            "name": "medium",
+                            "desc": "Medium"
+                          },
+                          {
+                            "name": "fast",
+                            "desc": "Fast"
+                          }
+                        ],
+                        "inputAttrs": {
+                          "style": {
+                            "width": "6.4rem"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "field": {
+                        "binding": "options.fanCurve.log.min",
+                        "type": "valueSpinner",
+                        "labelText": "Min Power",
+                        "canEdit": true,
+                        "min": 0,
+                        "max": 100,
+                        "step": 1,
+                        "fmtMask": "##,##0",
+                        "units": "%",
+                        "labelAttrs": {
+                          "style": {
+                            "width": "5.5em"
+                          }
+                        },
+                        "style": {
+                          "marginLeft": ".25rem",
+                          "marginBottom": ".25rem"
+                        },
+                        "inputAttrs": {
+                          "style": {
+                            "width": "5rem"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "field": {
+                    "type": "fieldset",
+                    "legend": "Exponential Fan Curve",
+                    "cssClass": "fan-curve fan-curve-exp",
+
+                    "style": {
+                    },
+                    "attrs": {
+                      "data-bindingcontext": "settings"
+                    }
+                  },
+                  "options": [
+                    {
+                      "field": {
+                        "type": "div"
+                      },
+                      "options": [
+                        {
+                          "field": {
+                            "binding": "options.fanCurve.exp.start",
+                            "type": "valueSpinner",
+                            "labelText": "Start Temp",
+                            "canEdit": true,
+                            "min": 0,
+                            "max": 500,
+                            "step": 1,
+                            "fmtMask": "##,##0",
+                            "units": "&deg;",
+                            "labelAttrs": {
+                              "style": {
+                                "width": "5.5em"
+                              }
+                            },
+                            "style": {
+                              "marginLeft": ".25rem",
+                              "marginBottom": ".25rem"
+                            },
+                            "inputAttrs": {
+                              "style": {
+                                "width": "5rem"
+                              }
+                            }
+                          }
+                        },
+                        {
+                          "field": {
+                            "binding": "values.units",
+                            "type": "span",
+                            "cssClass": "picSpinner-units picUnits"
+                          }
+                        }
+
+                      ]
+                    },
+                    {
+                      "field": {
+                        "type": "pickList",
+                        "labelText": "Ramp",
+                        "binding": "options.fanCurve.exp.ramp",
+                        "bindColumn": 0,
+                        "displayColumn": 1,
+                        "style": {
+                          "display": "block",
+                          "marginLeft": ".25rem",
+                          "marginBottom": ".25rem"
+                        },
+                        "labelAttrs": {
+                          "style": {
+                            "width": "5.5rem"
+                          }
+                        },
+                        "columns": [
+                          {
+                            "hidden": true,
+                            "binding": "name",
+                            "text": "name",
+                            "style": {
+                              "whiteSpace": "nowrap"
+                            }
+                          },
+                          {
+                            "hidden": false,
+                            "binding": "desc",
+                            "text": "Description",
+                            "style": {
+                              "whiteSpace": "nowrap"
+                            }
+                          }
+                        ],
+                        "items": [
+                          {
+                            "name": "slow",
+                            "desc": "Slow"
+                          },
+                          {
+                            "name": "medium",
+                            "desc": "Medium"
+                          },
+                          {
+                            "name": "fast",
+                            "desc": "Fast"
+                          }
+                        ],
+                        "inputAttrs": {
+                          "style": {
+                            "width": "6.4rem"
+                          }
+                        }
+                      }
+                    },
+                    {
+                      "field": {
+                        "binding": "options.fanCurve.exp.min",
+                        "type": "valueSpinner",
+                        "labelText": "Min Power",
+                        "canEdit": true,
+                        "min": 0,
+                        "max": 100,
+                        "step": 1,
+                        "fmtMask": "##,##0",
+                        "units": "%",
+                        "labelAttrs": {
+                          "style": {
+                            "width": "5.5em"
+                          }
+                        },
+                        "style": {
+                          "marginLeft": ".25rem",
+                          "marginBottom": ".25rem"
+                        },
+                        "inputAttrs": {
+                          "style": {
+                            "width": "5rem"
+                          }
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "field": {
+                    "type": "fieldset",
+                    "legend": "Custom Fan Curve",
+                    "cssClass": "fan-curve fan-curve-custom",
+                    "style": {
+                    },
+                    "attrs": {
+                      "data-bindingcontext": "settings"
+                    }
+                  },
+                  "options": [
+                    {
+                      "field": {
+                        "type": "div",
+                        "style": {
+                          "width": "27rem"
+                        },
+                        "html": "The script determines how to set the fan power. See <a href='https://github.com/rstrouse/relayEquipmentManager/wiki/Sequent-Microsystems-Boards#sequent-smart-fan' target='_blank'>Sequent Smart Fan Wiki</a> for instructions.",
+                        "cssClass": "script-advanced-instructions"
+                      }
+                    },
+                    {
+                      "field": {
+                        "type": "div",
+                        "style": {
+                          "display": "block",
+                          "lineHeight": "1.2"
+                        },
+                        "class": "script-editor",
+                        "binding": "test-binding"
+                      },
+                      "options": [
+                        {
+                          "default": "return 0;",
+                          "field": {
+                            "binding": "options.fanPowerFn",
+                            "type": "scriptEditor",
+                            "labelText": "Fan Power Function",
+                            "prefix": "(options, values, info) => {",
+                            "suffix": "}",
+                            "codeStyle": "{ maxHeight: '300px', overflow: 'auto' }",
+                            "canEdit": true,
+                            "style": {
+                              "marginLeft": "-.5rem",
+                              "marginRight": "-.5rem",
+                              "marginBottom": ".25rem"
+                            }
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          ]
+        }
+      ],
+      "interfaces": [ "i2c" ]
     }
+
   ]
 }

--- a/i2c-bus/SequentSmartFan_v6.ts
+++ b/i2c-bus/SequentSmartFan_v6.ts
@@ -1,0 +1,480 @@
+﻿//SMART FAN
+import * as fs from 'fs';
+import { logger } from "../logger/Logger";
+import { utils } from "../boards/Constants";
+import { setTimeout, clearTimeout } from "timers";
+import * as extend from "extend";
+import { Buffer } from "buffer";
+import { i2cDeviceBase } from "./I2cBus";
+import { webApp } from "../web/Server";
+import { DeviceBinding, cont, GpioPin } from "../boards/Controller";
+
+export class SequentSmartFanV6 extends i2cDeviceBase {
+    protected regs = {
+        I2C_MEM_FAN_POWER: 0,
+              
+        I2C_MEM_TIME_TO_STOP_SET: 5, //2bytes
+        I2C_MEM_TIME_TO_STOP_REM: 7,
+
+        hwVersion: 100,
+        hwVersion_minor: 101,
+      
+        SLAVE_BUFF_SIZE: 108
+    };
+
+    protected powerPin: GpioPin;
+    protected _timerRead: NodeJS.Timeout;
+    protected _infoRead: NodeJS.Timeout;
+    protected _suspendPolling: number = 0;
+    protected processing = 0;
+    protected _pollInformationInterval = 3000;
+
+    public evalFanPower: Function;
+
+    protected logError(err, msg?: string) { logger.error(`${this.device.name} ${typeof msg !== 'undefined' ? msg + ' ' : ''}${typeof err !== 'undefined' ? err.message : ''}`); }
+    protected get version(): number { return typeof this.device !== 'undefined' && this.options !== 'undefined' && typeof this.device.info !== 'undefined' ? parseFloat(this.device.info.firmware) : 0 }
+    
+    protected get fanCurve(): { curve: string, linear: { start: number, end: number, min: number }, exp: { start: number, min: number, ramp: string }, log: { start: number, min: number, ramp: string } } {
+        if (typeof this.options.units === 'undefined') this.options.units = 'C';
+
+        if (typeof this.options.fanCurve === 'undefined') {
+            this.options.fanCurve = { curve: 'linear' };
+        }
+
+        if (typeof this.options.fanCurve.linear === 'undefined') this.options.fanCurve.linear = {
+            start: Math.round(utils.convert.temperature.convertUnits(30, 'C', this.options.units)),
+            end: Math.round(utils.convert.temperature.convertUnits(70, 'C', this.options.units)),
+            min: 0
+        };
+
+        if (typeof this.options.fanCurve.exp === 'undefined') this.options.fanCurve.exp = {
+            start: utils.convert.temperature.convertUnits(30, 'C', this.options.units),
+            min: 0,
+            ramp: 'slow'
+        };
+
+        if (typeof this.options.fanCurve.log === 'undefined') this.options.fanCurve.log = {
+            start: utils.convert.temperature.convertUnits(30, 'C', this.options.units),
+            min: 0,
+            ramp: 'slow'
+        };
+        
+        return this.options.fanCurve;
+    }
+
+    protected changeUnits(from: string, to: string) {
+        //if (from === to) return;
+        //console.log(`Changing units from ${from} to ${to}`);
+        let fc = this.fanCurve;
+        let ct = utils.convert.temperature.convertUnits;
+        //console.log(fc);
+        this.options.fanCurve.linear.start = utils.convert.temperature.convertUnits(fc.linear.start, from, to);
+        this.options.fanCurve.linear.end = utils.convert.temperature.convertUnits(fc.linear.end, from, to);
+        this.options.fanCurve.exp.start = utils.convert.temperature.convertUnits(fc.exp.start, from, to);
+        this.options.fanCurve.log.start = utils.convert.temperature.convertUnits(fc.log.start, from, to);
+        //console.log(fc);        
+        this.values.cpuTemp = ct(this.values.cpuTemp, from, to);           
+        this.options.units = this.values.units = to;     
+        webApp.emitToClients('i2cDataValues', { bus: this.i2c.busNumber, address: this.device.address, values: this.values });
+    }
+    
+    public async initAsync(deviceType): Promise<boolean> {
+        try {
+            if (typeof this.options.fanCurve === 'undefined' || typeof this.options.fanCurve === 'string') {
+                this.options.fanCurve = undefined;
+                let fc = this.fanCurve;
+                logger.info(`Setting ${this.device.name} inital curves ${fc.curve}`);
+            }
+            
+            this.stopPolling();
+
+            if (typeof this.options.readInterval === 'undefined') {
+                this.options.readInterval = 3000;
+            }            
+
+            this.options.readInterval = Math.max(3000, this.options.readInterval);
+            
+            if (typeof this.options.name !== 'string' || this.options.name.length === 0) {
+                this.device.name = this.options.name = deviceType.name;
+            }
+            else { 
+                this.device.name = this.device.options.name;
+            } 
+
+            if (typeof this.options.units === 'undefined') {
+                this.options.units = this.device.values.units = 'C';
+            }
+
+            if (typeof this.options.fanPowerFn !== 'undefined' && this.options.fanPowerFn.length > 0) {
+                this.evalFanPower = new Function('options', 'values', 'info', this.options.fanPowerFn);
+            }
+
+            this.powerPin = await cont.gpio.setPinAsync(1, 32,
+                {
+                    isActive: this.device.isActive,
+                    name: `${this.device.name} Power`, direction: 'output',
+                    isInverted: false, initialState: 'off', debounceTimeout: 0
+                }
+            );
+            
+            if (this.device.isActive) {
+                await this.getHwFwVer();                      
+                await this.getFanPower();                           
+                await this.getStatus();
+            }
+        }
+        catch (err) { 
+            this.logError(err); return Promise.resolve(false); 
+        }   
+        finally {
+            setTimeout(() => { this.pollReadings(); }, 5000);
+        }
+    }
+
+    public async setOptions(opts): Promise<any> {
+        try {
+            this.suspendPolling = true;
+            if (typeof this.options.units === 'undefined') this.options.units = 'C';
+            if (typeof opts.name !== 'undefined' && this.device.name !== opts.name) this.options.name = this.device.name = opts.name;            
+            if (typeof opts.readInterval !== 'undefined') this.options.readInterval = opts.readInterval;            
+            if (typeof opts.fanCurve !== 'undefined') {
+                let fc = this.fanCurve;
+                if (typeof opts.fanCurve.curve !== 'undefined') fc.curve = opts.fanCurve.curve;
+                if (typeof opts.fanCurve.linear !== 'undefined') {
+                    let curve = opts.fanCurve.linear;
+                    if (typeof curve.start !== 'undefined') fc.linear.start = curve.start;
+                    if (typeof curve.end !== 'undefined') fc.linear.end = curve.end;
+                    if (typeof curve.min !== 'undefined') fc.linear.min = curve.min;
+                }
+                if (typeof opts.fanCurve.exp !== 'undefined') {
+                    let curve = opts.fanCurve.exp;
+                    if (typeof curve.start !== 'undefined') fc.exp.start = curve.start;
+                    if (typeof curve.ramp !== 'undefined') fc.exp.ramp = curve.ramp;
+                    if (typeof curve.min !== 'undefined') fc.exp.min = curve.min;
+                }
+                if (typeof opts.fanCurve.log !== 'undefined') {
+                    let curve = opts.fanCurve.log;
+                    if (typeof curve.start !== 'undefined') fc.log.start = curve.start;
+                    if (typeof curve.ramp !== 'undefined') fc.log.ramp = curve.ramp;
+                    if (typeof curve.min !== 'undefined') fc.log.min = curve.min;
+                }
+            }            
+            if (typeof opts.units !== 'undefined' && this.options.units !== opts.units) this.setUnits(opts.units);
+
+            if (typeof opts.fanPowerFn !== 'undefined' && opts.fanPowerFn !== this.options.fanPowerFn) {
+                this.evalFanPower = new Function('options', 'values', 'info', opts.fanPowerFn);
+                this.options.fanPowerFn = opts.fanPowerFn;
+            }
+            return this.options;
+        }
+        catch (err) { this.logError(err); Promise.reject(err); }
+        finally { this.suspendPolling = false; }
+    }
+
+    public setUnits(value: string): Promise<boolean> {
+        try {
+            if (!['C', 'F', 'K'].includes(value.toUpperCase())) return Promise.reject(new Error(`Cannot set units to ${value}`));
+            let prevUnits = this.values.units || 'C';
+            this.changeUnits(prevUnits, value);
+        }
+        catch (err) { this.logError(err); }
+    }
+
+    protected async getHwFwVer() {
+        try {
+            if (this.i2c.isMock) {
+                this.info.fwVersion =  `1.0 Mock`;
+                this.info.hwVersion = `6.0 Mock`;
+            } else {                            
+                this.info.hwVersion = `6.0`;   
+                this.info.fwVersion = `1.0`;                 
+            }
+        } catch (err) { logger.error(`${this.device.name} error getting firmware version: ${err.message}`); }
+    }
+
+    protected async getFanPower() {
+        try {
+            if (this.i2c.isMock) Math.round(Math.random() * 100); 
+        
+            let fanPower = await this.i2c.readByte(this.device.address, this.regs.I2C_MEM_FAN_POWER);
+            fanPower = Math.round((255 - fanPower) / 2.55);
+
+            this.values.fanPower = fanPower;
+    
+        } catch (err) { logger.error(`${this.device.name} error getting fan power: ${err.message}`); }
+    }
+
+    protected calcFanPower(): number {
+        let val: number = 0, _val: number = 0;
+        if (this.fanCurve.curve === 'custom') {
+            val = _val = typeof this.evalFanPower === 'function' ? Math.round(this.evalFanPower(this.options, this.values, this.info)) : 0;
+            if (isNaN(val)) {
+                logger.error(`Sequent Smart Fan: Result of expression is isNaN.  Function evaluated is ${this.evalFanPower.toString()}`);
+                val = 0;
+            }
+        }
+        else if (this.fanCurve.curve === 'linear') {
+            let curve = this.fanCurve.linear;
+            let slope = (curve.end - curve.start) * .01;
+            _val = (slope * (this.values.cpuTemp - curve.start)) + (curve.min || 0);
+            _val = Math.max(Math.min(_val, 100), 0);
+            val = Math.max(_val, curve.min);
+        }
+        else if (this.fanCurve.curve === 'log') {
+            let curve = this.fanCurve.log;
+            let b = 1.06;
+            let temp = utils.convert.temperature.convertUnits(this.values.cpuTemp, this.values.units, 'C');
+            let start = utils.convert.temperature.convertUnits(curve.start, this.values.units, 'C');
+
+            switch (curve.ramp) {
+                case 'slow':
+                    b = 1.08;
+                case 'medium':
+                    b = 1.06;
+                case 'fast':
+                    b = 1.04;
+            }
+            _val = Math.log(Math.max(.001, temp - start)) / Math.log(b);          
+            _val = Math.max(Math.min(_val, 100), 0);
+            val = Math.max(_val, curve.min);
+        }
+        else if (this.fanCurve.curve === 'exp') {
+            let curve = this.fanCurve.exp;
+            let temp = utils.convert.temperature.convertUnits(this.values.cpuTemp, this.values.units, 'C');
+            let start = utils.convert.temperature.convertUnits(curve.start, this.values.units, 'C');
+            if (temp > start) {
+                let b = 1.07;
+                switch (curve.ramp) {
+                    case 'slow':
+                        b = 1.07;
+                        break;
+                    case 'medium':
+                        b = 1.1;
+                        break;
+                    case 'fast':
+                        b = 1.15;
+                        break;
+                }
+                _val = Math.pow(b, (this.values.cpuTemp - curve.start)) + curve.min - 1;
+            }
+            else
+                _val = 0;
+            _val = Math.max(Math.min(_val, 100), 0);
+            val = Math.max(_val, curve.min)
+        }
+        this.values.fanPowerFnVal = _val;
+        return Math.round(Math.max(Math.min(val, 100), 0));
+    }
+
+    protected async setFanPower() {
+        try {
+            let val = this.calcFanPower();
+            if (val !== this.values.fanPower) {             
+                // Sequent occupies a gpio pin to turn on and off the fan.
+                let pwr = Math.round(255 - Math.min(val * 2.55, 255));
+                if (typeof this.powerPin !== 'undefined')  {
+                    // Device was initially configured inactive, now active (without restart)
+                    if(!this.powerPin.isActive) {
+                        await this.powerPin.setPinAsync({                            
+                            isActive: true,
+                        })      
+                    }              
+                    this.powerPin.setPinStateAsync((val > 0 ? 1 : 0));
+                }
+                let buffer = Buffer.from([pwr]);
+                logger.verbose(`${this.device.name} setFanPower = ${pwr} val = ${val}`);
+                if (!this.i2c.isMock)
+                    await this.i2c.writeI2cBlock(this.device.address, this.regs.I2C_MEM_FAN_POWER, 1, buffer);
+                else {
+                    this.values.fanPower = val;
+                }        
+            }
+        }
+        catch (err) { logger.error(`${this.device.name} error setting fan power: ${err.message}`); }
+    }
+   
+    protected getCpuTemp(): number {
+        try {                        
+            if (this.i2c.isMock) {
+                return utils.convert.temperature.convertUnits(72 + (Math.round((5 * Math.random()) * 100) / 100), 'f', this.values.units);
+            }
+            if (fs.existsSync('/sys/class/thermal/thermal_zone0/temp')) {
+                let buffer = fs.readFileSync('/sys/class/thermal/thermal_zone0/temp');
+                let cpuTemp: number;
+                cpuTemp = utils.convert.temperature.convertUnits(parseInt(buffer.toString().trim(), 10) / 1000, 'C', this.values.units);
+                this.values.cpuTemp = cpuTemp;
+                let ct = utils.convert.temperature.convertUnits;
+                this.values.cpuTempF = ct(cpuTemp, this.values.units, 'F');
+                this.values.cpuTempC = ct(cpuTemp, this.values.units, 'C');
+                this.values.cpuTempK = ct(cpuTemp, this.values.units, 'K');
+               
+                return cpuTemp;
+            }
+        } catch (err) { logger.error(`${this.device.name} error getting cpu temp: ${err.message}`); }
+    }  
+  
+    protected pollDeviceInformation() {
+        try {
+            if (this._infoRead) clearTimeout(this._infoRead);
+            this._infoRead = null;
+            if (!this.suspendPolling && this.device.isActive) {
+                this.getDeviceInformation();
+            }
+        }
+        catch (err) { this.logError(err, 'Error Polling Device Information'); }
+        finally { this._infoRead = setTimeout(() => { this.pollDeviceInformation(); }, this._pollInformationInterval); }
+    }
+
+    protected async takeReadings(): Promise<boolean> {
+        try {
+            let _values = JSON.parse(JSON.stringify(this.values));            
+            await this.setFanPower(); //not a reading; but set the value and then make sure it is set properly.
+            await this.getCpuTemp();
+            await this.getFanPower();
+            if (this.values.fanPower !== _values.fanPower || this.values.fanPowerFnVal !== _values.fanPowerFnVal) {
+                webApp.emitToClients('i2cDataValues', { bus: this.i2c.busNumber, address: this.device.address, values: this.values });
+            }
+            this.emitFeeds();
+            return true;
+        }
+        catch (err) { this.logError(err, 'Error taking device readings'); }
+    }
+
+    protected pollReadings() {
+        try {
+            if (this._timerRead) clearTimeout(this._timerRead);
+            this._timerRead == null;
+            if (!this.suspendPolling && this.device.isActive) {
+                (async () => {
+                    await this.takeReadings()
+                        .catch(err => { logger.error(err); });
+                })();
+
+
+            }
+        }
+        catch (err) { this.logError(err, 'Error Polling Device Values'); }
+        finally { this._timerRead = setTimeout(() => { this.pollReadings(); }, this.options.readInterval) }
+    }
+
+    public get suspendPolling(): boolean { 
+        if (this._suspendPolling > 0) logger.warn(`${this.device.name} Suspend Polling ${this._suspendPolling}`); 
+        return this._suspendPolling > 0; 
+    
+    }
+    public set suspendPolling(val: boolean) {
+        this._suspendPolling = Math.max(0, this._suspendPolling + (val ? 1 : -1));
+    }
+
+    public stopPolling() {
+        this.suspendPolling = true;
+        if (this._timerRead) clearTimeout(this._timerRead);
+        if (this._infoRead) clearTimeout(this._infoRead);
+        this._timerRead = this._infoRead = null;
+        this._suspendPolling = 0;
+    }
+
+    public async getStatus(): Promise<boolean> {
+        try {
+            this.suspendPolling = true;
+            return true;
+        }
+        catch (err) { logger.error(`Error getting info ${typeof err !== 'undefined' ? err.message : ''}`); return Promise.reject(err); }
+        finally { this.suspendPolling = false; }
+    }
+
+    public async getDeviceInformation(): Promise<boolean> {
+        try {
+            this.suspendPolling = true;
+            await this.getStatus();
+            webApp.emitToClients('i2cDeviceInformation', { bus: this.i2c.busNumber, address: this.device.address, info: this.device.info });
+        }
+        catch (err) { logger.error(`Error retrieving device status: ${typeof err !== 'undefined' ? err.message : ''}`); return Promise.reject(err); }
+        finally { this.suspendPolling = false; }
+    }
+
+    public async closeAsync(): Promise<void> {
+        try {
+            await this.stopPolling();
+            await super.closeAsync();
+            return Promise.resolve();
+        }
+        catch (err) { return this.logError(err); }
+    }
+
+    public getValue(prop: string) {
+        let p = prop.toLowerCase();
+        switch (p) {
+            case 'cputempc':
+                return utils.convert.temperature.convertUnits(this.getCpuTemp(), this.values.units, 'C');
+            case 'cputempf':
+                return utils.convert.temperature.convertUnits(this.getCpuTemp(), this.values.units, 'F');
+            case 'cputempk':
+                return utils.convert.temperature.convertUnits(this.getCpuTemp(), this.values.units, 'K');        
+            case 'fwversion':
+                return this.info.fwVersion;
+            default:
+                return this.values[prop];
+        }
+    }
+
+    public calcMedian(prop: string, values: any[]) {
+        let p = prop.toLowerCase();
+        switch (p) {
+            case 'cputempc':
+            case 'cputempf':
+            case 'cputempk':        
+            case 'inputvoltage':
+            case 'pivoltage':
+                return super.calcMedian(prop, values);
+            case 'fwversion':
+                return this.info.fwVersion;
+            default:
+                // Determine whether this is an object.
+                if (p.startsWith('in') || p.startsWith('out')) {
+                    if (values.length > 0 && typeof values[0] === 'object') {
+                        let io = this.getValue(prop);
+                        if (typeof io !== 'undefined') {
+                            let vals = [];
+                            for (let i = 0; i < values.length; i++) vals.push(values[i].value);
+                            return extend(true, {}, io, { value: super.calcMedian(prop, vals) })
+                        }
+                    }
+                    else return super.calcMedian(prop, values);
+                }
+                else logger.error(`${this.device.name} error calculating median value for ${prop}.`);
+        }
+    }
+
+    public setValue(prop: string, value) {
+        let p = prop.toLowerCase();
+        if (prop.includes('temp')) {
+
+            if (prop.slice(-1) === this.options.units) { 
+                this.values.cpuTemp = value; 
+            }
+            else {
+                this.values.cpuTemp = utils.convert.temperature.convertUnits(value, prop.slice(-1), this.options.units);
+            }
+            webApp.emitToClients('i2cDeviceInformation', { bus: this.i2c.busNumber, address: this.device.address, info: this.device.info });
+        }      
+    }
+
+    public async getDeviceState(binding: string | DeviceBinding): Promise<any> {
+        try {
+            let bind = (typeof binding === 'string') ? new DeviceBinding(binding) : binding;
+            // We need to know what value we are referring to.
+            if (typeof bind.params[0] === 'string') return this.getValue(bind.params[0]);
+            return this.values;
+        } catch (err) { return Promise.reject(err); }
+    }
+
+    public async setValues(vals): Promise<any> {
+        try {
+            this.suspendPolling = true;
+            return Promise.resolve(this.values);
+        }
+        catch (err) { this.logError(err); Promise.reject(err); }
+        finally { this.suspendPolling = false; }
+    }   
+}

--- a/pinouts/raspi-4b-bookworm.json
+++ b/pinouts/raspi-4b-bookworm.json
@@ -1,6 +1,6 @@
 ﻿{
-  "name": "Raspberry Pi (Legacy OS)",
-  "desc": "All current models up to 4B running the Legacy OS option",
+  "name": "Raspberry Pi 4B - Bookworm OS",
+  "desc": "Tested on a 4B running Bookworm",
   "icon": "fab fa-raspberry-pi",
   "overlays": [
     {
@@ -491,7 +491,7 @@
           "id": 3,
           "name": "BCM 2",
           "type": "gpio",
-          "gpioId": 2
+          "gpioId": 514
         },
         {
           "id": 4,
@@ -502,7 +502,7 @@
           "id": 5,
           "name": "BCM 3",
           "type": "gpio",
-          "gpioId": 3
+          "gpioId": 515
         },
         {
           "id": 6,
@@ -513,13 +513,13 @@
           "id": 7,
           "name": "BCM 4",
           "type": "gpio",
-          "gpioId": 4
+          "gpioId": 516
         },
         {
           "id": 8,
           "name": "BCM 14",
           "type": "gpio",
-          "gpioId": 14
+          "gpioId": 526
         },
         {
           "id": 9,
@@ -530,25 +530,25 @@
           "id": 10,
           "name": "BCM 15",
           "type": "gpio",
-          "gpioId": 15
+          "gpioId": 527
         },
         {
           "id": 11,
           "name": "BCM 17",
           "type": "gpio",
-          "gpioId": 17
+          "gpioId": 529
         },
         {
           "id": 12,
           "name": "BCM 18",
           "type": "gpio",
-          "gpioId": 18
+          "gpioId": 530
         },
         {
           "id": 13,
           "name": "BCM 27",
           "type": "gpio",
-          "gpioId": 27
+          "gpioId": 539
         },
         {
           "id": 14,
@@ -559,13 +559,13 @@
           "id": 15,
           "name": "BCM 22",
           "type": "gpio",
-          "gpioId": 22
+          "gpioId": 534
         },
         {
           "id": 16,
           "name": "BCM 23",
           "type": "gpio",
-          "gpioId": 23
+          "gpioId": 535
         },
         {
           "id": 17,
@@ -576,13 +576,13 @@
           "id": 18,
           "name": "BCM 24",
           "type": "gpio",
-          "gpioId": 24
+          "gpioId": 536
         },
         {
           "id": 19,
           "name": "BCM 10",
           "type": "gpio",
-          "gpioId": 10
+          "gpioId": 522
         },
         {
           "id": 20,
@@ -593,25 +593,25 @@
           "id": 21,
           "name": "BCM 9",
           "type": "gpio",
-          "gpioId": 9
+          "gpioId": 521
         },
         {
           "id": 22,
           "name": "BCM 25",
           "type": "gpio",
-          "gpioId": 25
+          "gpioId": 537
         },
         {
           "id": 23,
           "name": "BCM 11",
           "type": "gpio",
-          "gpioId": 11
+          "gpioId": 523
         },
         {
           "id": 24,
           "name": "BCM 8",
           "type": "gpio",
-          "gpioId": 8
+          "gpioId": 520
         },
         {
           "id": 25,
@@ -622,25 +622,25 @@
           "id": 26,
           "name": "BCM 7",
           "type": "gpio",
-          "gpioId": 7
+          "gpioId": 519
         },
         {
           "id": 27,
           "name": "BCM 0",
           "type": "gpio",
-          "gpioId": 0
+          "gpioId": 512
         },
         {
           "id": 28,
           "name": "BCM 1",
           "type": "gpio",
-          "gpioId": 1
+          "gpioId": 513
         },
         {
           "id": 29,
           "name": "BCM 5",
           "type": "gpio",
-          "gpioId": 5
+          "gpioId": 517
         },
         {
           "id": 30,
@@ -651,19 +651,19 @@
           "id": 31,
           "name": "BCM 6",
           "type": "gpio",
-          "gpioId": 6
+          "gpioId": 518
         },
         {
           "id": 32,
           "name": "BCM 12",
           "type": "gpio",
-          "gpioId": 12
+          "gpioId": 524
         },
         {
           "id": 33,
           "name": "BCM 13",
           "type": "gpio",
-          "gpioId": 13
+          "gpioId": 525
         },
         {
           "id": 34,
@@ -675,7 +675,7 @@
           "id": 35,
           "name": "BCM 19",
           "type": "gpio",
-          "gpioId": 35
+          "gpioId": 531
         },
         {
           "id": 36,
@@ -687,13 +687,13 @@
           "id": 37,
           "name": "BCM 26",
           "type": "gpio",
-          "gpioId": 26
+          "gpioId": 528
         },
         {
           "id": 38,
           "name": "BCM 20",
           "type": "gpio",
-          "gpioId": 20
+          "gpioId": 532
         },
         {
           "id": 39,
@@ -705,7 +705,7 @@
           "id": 40,
           "name": "BCM 21",
           "type": "gpio",
-          "gpioId": 21
+          "gpioId": 533
         }
       ]
     }


### PR DESCRIPTION
This PR adds support for Sequent Systems Smart Fan v6, along with support for Raspi OS Bookworm on a 4B.

The v6 Smart Fan uses a different GPIO pin from previous generations, and also lacks the capabilities drop from v4 onward. As I don't have an older device to test with, I opted to create a new module for this generation instead of sharing the existing one. This new module only contains the capabilities of the v4 and onward, and supports the changed GPIO pin in v6 (?). Some other general fixes as well.

Raspberry Pi Bookworm changes how GPIO pins are addressed. Per @rstrouse in rstrouse#61 (comment)

> I have found why your GPIO numbers seem so strange. The pi engineers are now identifying gpios by touple which includes the chip id (2) in the gpio. Honestly, this is the same approach as other boards such as the orange pi and probably what raspberry should have been doing all along. Perhaps there is a future for multiple gpio headers on the same board. For now the problem is that the pi 5 does not have the gpio chip embedded (chip id 0). It is external to the cpu on chip id (2).

To address this, I have included a new pinout profile that I have tested with the Raspberry 4B. I am almost certain the 5 will need a different pinout, but unsure of other 4 variants and earlier.