### PR TITLE
Updated CPU temperature reading in SequentIO class to fallback to OS thermal zones

### DIFF
--- a/i2c-bus/SequentIO.ts
+++ b/i2c-bus/SequentIO.ts
@@ -10,6 +10,8 @@ import { i2cDeviceBase } from "./I2cBus";
 import { webApp } from "../web/Server";
 import { I2cDevice, DeviceBinding } from "../boards/Controller";
 import { LatchTimers } from "../devices/AnalogDevices";
+import * as fs from 'fs';
+
 export class SequentIO extends i2cDeviceBase {
     protected regs = {
         rs485Settings: 65,
@@ -221,6 +223,13 @@ export class SequentIO extends i2cDeviceBase {
     protected async getCpuTemp() {
         try {
             this.info.cpuTemp = (this.i2c.isMock) ? Math.round(19.0 + Math.random()) : await this.i2c.readByte(this.device.address, this.regs.cpuTemp);
+
+            if(typeof(this.info.cpuTemp) === 'undefined' || this.info.cpuTemp <= 0) {
+                if (fs.existsSync('/sys/class/thermal/thermal_zone0/temp')) {
+                    let buffer = fs.readFileSync('/sys/class/thermal/thermal_zone0/temp');
+                    this.info.cpuTemp = (parseInt(buffer.toString().trim(), 10) / 1000);
+                }
+            }
         } catch (err) { logger.error(`${this.device.name} error getting cpu temp: ${err.message}`); }
     }
     protected async getSourceVolts() {


### PR DESCRIPTION
Updated CPU temperature reading in SequentIO class to fallback to OS thermal zones.  This changes the behavior so the temp is read from from `/sys/class/thermal/thermal_zone0/temp` if unavailable on the I2C bus. I don't know if this is a change in the latest version of the BAS card, or a change somewhere else,  but this modification preserves the existing functionality and only falls back if the originally returned value is undefined or 0.